### PR TITLE
docs: fix configuration sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ bundle
 
 <match **>
   @type zulip
-  api_endpoint https://zulip.example.com/api/v1/messages
+  site https://zulip.example.com
   bot_email_address test-bot@example.com
   bot_api_key xxxxxxxxxxxxxxxxxxxxxxxxxx
 </match>


### PR DESCRIPTION
Update the sample configuration to use the correct parameter `site` with the base URL, instead of the incorrect `api_endpoint`.

Fix #13